### PR TITLE
Support Scala 3.0.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -4,12 +4,12 @@ import de.tobiasroeser.mill.vcs.version.VcsVersion
 
 val dottyVersions = sys.props.get("dottyVersion").toList
 
-val scalaVersions = "2.11.12" :: "2.12.13" :: "2.13.4" :: "3.0.0-RC3" :: dottyVersions
+val scalaVersions = "2.11.12" :: "2.12.13" :: "2.13.4" :: "3.0.0" :: dottyVersions
 val scala2Versions = scalaVersions.filter(_.startsWith("2."))
 
 val scalaJSVersions = for {
   scalaV <- scalaVersions
-  scalaJSV <- Seq("0.6.33", "1.4.0")
+  scalaJSV <- Seq("0.6.33", "1.5.1")
   if scalaV.startsWith("2.") || scalaJSV.startsWith("1.")
 } yield (scalaV, scalaJSV)
 

--- a/mill
+++ b/mill
@@ -3,7 +3,7 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.9.5-48-4ad87f
+DEFAULT_MILL_VERSION=0.9.6-61-bd7927
 
 set -e
 


### PR DESCRIPTION
- Bump Scala.js to 1.5.1
- Bump Mill to 0.9.6-61-bd7927