### PR TITLE
#111 Fix `Args` in Scala 3

### DIFF
--- a/sourcecode/src-3/sourcecode/Macros.scala
+++ b/sourcecode/src-3/sourcecode/Macros.scala
@@ -205,8 +205,8 @@ object Macros {
     }
 
     val texts0 = param.map(_.foldRight('{List.empty[Text[_]]}) {
-      case (vd @ ValDef(nme, _, optV), l) =>
-        '{Text(${optV.fold('None)(_.asExpr)}, ${Expr(nme)}) :: $l}
+      case (vd @ ValDef(nme, _, _), l) =>
+        '{Text(${Ref(vd.symbol).asExpr}, ${Expr(nme)}) :: $l}
     })
     val texts = texts0.foldRight('{List.empty[List[Text[_]]]}) {
       case (l, acc) =>

--- a/sourcecode/test/src/sourcecode/ArgsTests.scala
+++ b/sourcecode/test/src/sourcecode/ArgsTests.scala
@@ -7,14 +7,8 @@ object ArgsTests {
 
     def debug(implicit arguments: sourcecode.Args): Unit = args = arguments.value.map(_.map(t => t.source -> t.value))
 
-    // FIXME Can't manage to get the arg values from dotty…
-    val checkValues = !TestUtil.isDotty
-
     def check(expected: Seq[Seq[(String, Any)]]): Unit =
-      if (checkValues)
-        assert(args == expected, s"Expected: $expected, got: $args")
-      else
-        assert(args.map(_.map(_._1)) == expected.map(_.map(_._1)), s"Expected: ${expected.map(_.map(_._1))}, got: ${args.map(_.map(_._1))}")
+      assert(args == expected, s"Expected: $expected, got: $args")
 
     def foo(p1: String, p2: Long, p3: Boolean)(foo: String, bar: String): Unit = {
       debug


### PR DESCRIPTION
Fixes #111 

This PR fixes the behavior of `Args` in Scala 3 - the values are now actually there.