### PR TITLE
Fix NullPointerException when using sourcecode.File in Scala 3 repl

### DIFF
--- a/sourcecode/src-3/sourcecode/Macros.scala
+++ b/sourcecode/src-3/sourcecode/Macros.scala
@@ -147,7 +147,7 @@ object Macros {
 
   def fileImpl(using Quotes): Expr[sourcecode.File] = {
     import quotes.reflect._
-    val file = quotes.reflect.Position.ofMacroExpansion.sourceFile.jpath.toAbsolutePath.toString
+    val file = quotes.reflect.Position.ofMacroExpansion.sourceFile.path
     '{sourcecode.File(${Expr(file)})}
   }
 


### PR DESCRIPTION
In analogy to #153 fixes a NullPointerException when using `sourcecode.File` in the REPL.

