### PR TITLE
Correctly handle backticked macro keyword in Scala 3

### DIFF
--- a/sourcecode/src-3/sourcecode/Macros.scala
+++ b/sourcecode/src-3/sourcecode/Macros.scala
@@ -64,7 +64,18 @@ trait ArgsMacros {
 }
 
 object Util{
-  def isSynthetic(using Quotes)(s: quotes.reflect.Symbol) = isSyntheticName(getName(s))
+  def isSynthetic(using Quotes)(s: quotes.reflect.Symbol) =
+    isSyntheticAlt(s)
+
+  def isSyntheticAlt(using Quotes)(s: quotes.reflect.Symbol) = {
+    import quotes.reflect._
+    s.flags.is(Flags.Synthetic) || s.isClassConstructor || s.isLocalDummy || isScala2Macro(s)
+  }
+  def isScala2Macro(using Quotes)(s: quotes.reflect.Symbol) = {
+    import quotes.reflect._
+    (s.flags.is(Flags.Macro) && s.owner.flags.is(Flags.Scala2x)) ||
+      (s.flags.is(Flags.Macro) && !s.flags.is(Flags.Inline))
+  }
   def isSyntheticName(name: String) = {
     name == "<init>" || (name.startsWith("<local ") && name.endsWith(">")) || name == "$anonfun" || name == "macro"
   }

--- a/sourcecode/test/src/sourcecode/SpecialName.scala
+++ b/sourcecode/test/src/sourcecode/SpecialName.scala
@@ -1,0 +1,13 @@
+package sourcecode
+
+object SpecialName {
+
+  def macroValRun() = {
+    def keyword(implicit name: sourcecode.Name): String = name.value
+
+    val `macro` = keyword
+
+    assert(`macro` == "macro")
+  }
+
+}

--- a/sourcecode/test/src/sourcecode/Tests.scala
+++ b/sourcecode/test/src/sourcecode/Tests.scala
@@ -18,6 +18,7 @@ object Tests{
     EnumFull.run()
     NoSynthetic.run()
     Synthetic.run()
+    SpecialName.macroValRun()
     ManualImplicit()
     TextTests()
     ArgsTests()


### PR DESCRIPTION
Change the synthetic check to use flags and exposed methods instead of names.

#120 